### PR TITLE
Hotfix/carosel link showing underline

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -56,6 +56,15 @@
   color: white;
   font-size: 24px;
   font-weight: bold;
+
+  p {
+    margin-bottom: 0;
+    padding-left: 10px;
+  }
+
+  a {
+    text-decoration: none;
+  }
 }
 
 // Smallest device

--- a/app/views/foods/_food.html.erb
+++ b/app/views/foods/_food.html.erb
@@ -9,22 +9,22 @@
           <% else %>
             <p class="card-price ml-3 mb-0 mt-3">$<%= food.price %></p>
           <% end %>
-        </div>  
+        </div>
         <div class="d-flex flex-column">
-          <div class="card-details p-3">
+          <div class="card-details p-1">
             <h4><strong><%=h truncate(food.name, length: 15) %></strong></h4>
             <p><%=h truncate(food.description, length: 70) %></p>
           </div>
 
-          <div class="d-flex justify-content-center">
+          <div class="text-right pr-3">
             <button
-              class="btn btn-primary btn-cart w-75 mt-1"
+              class="btn btn-primary btn-cart"
               data-toggle="modal"
               data-target="#exampleModal"
               data-food-name="<%= food.name%>"
               data-food-price="<%= food.price%>"
               data-food-id="<%= food.id%>">
-              Add to cart</button>
+              <i class="fas fa-cart-plus"></i></button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Why

This pull request is needed because:

1. The cards on the landing page has underline when hovered over, plus the text is aligned more to the top.
2. The cards on the Restaurants show page is overflowing in SMALL screens (flowing out of the card).


## What

This pull request introduces the following:

 * No underline when hovering over cards in the landing page carousel
 * The text in the cards in the landing page carousel is centered and stays so in different dimensions
 * The cards in the Restaurants show page (list of foods) is no longer overflowing on my ipad


### Screenshot

<img width="339" alt="Screenshot 2021-09-18 at 11 03 22 AM" src="https://user-images.githubusercontent.com/11084577/133870363-bd8a3c8f-dcf3-4ba5-a2f2-317f1c2b2245.png">

## How to Test

Change screen dimensions

Mobile view:

<img width="354" alt="Screenshot 2021-09-18 at 11 04 40 AM" src="https://user-images.githubusercontent.com/11084577/133870438-fafa19d7-b737-4da8-89dd-fba70cbaddcb.png">

