### PR TITLE
Seed more restaurants

### DIFF
--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -1,14 +1,16 @@
 class RestaurantsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
-  
+
   def index
     # there are might be repeats, so we need a way to prevent adding repeats to the results
     location = params[:location]
     coordinates = retrieve_coordinates(location)
 
     if params[:query].present?
-      nearby_restaurants = Restaurant.near(coordinates, 5, units: :km) ? Restaurant.near(coordinates, 5, units: :km) : Restaurant.near('Singapore', 10, units: :km)
-      @restaurants = Restaurant.search_by_name_and_address(params[:query]) + nearby_restaurants
+      nearby_restaurants = Restaurant.near(coordinates, 5, :order => :distance) ? Restaurant.near(coordinates, 5, :order => :distance) : Restaurant.near('Singapore', 10, :order => :distance)
+      # @restaurants = Restaurant.search_by_name_and_address(params[:query]) + nearby_restaurants
+      raise
+      @restaurants = nearby_restaurants + Restaurant.search_by_name_and_address(params[:query])
     else
       @restaurants = Restaurant.all
     end

--- a/app/controllers/restaurants_controller.rb
+++ b/app/controllers/restaurants_controller.rb
@@ -8,8 +8,6 @@ class RestaurantsController < ApplicationController
 
     if params[:query].present?
       nearby_restaurants = Restaurant.near(coordinates, 5, :order => :distance) ? Restaurant.near(coordinates, 5, :order => :distance) : Restaurant.near('Singapore', 10, :order => :distance)
-      # @restaurants = Restaurant.search_by_name_and_address(params[:query]) + nearby_restaurants
-      raise
       @restaurants = nearby_restaurants + Restaurant.search_by_name_and_address(params[:query])
     else
       @restaurants = Restaurant.all

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -3,7 +3,12 @@ class Restaurant < ApplicationRecord
   validates :name, presence: true
   attribute :promo_status, :integer, default: 0
 
-  geocoded_by :address
+  geocoded_by :address,
+              latitude: :fetched_latitude,
+              longitude: :fetched_longitude
+  reverse_geocoded_by :latitude, :longitude
+  after_validation :geocode, unless: ->(obj){ obj.address.present? and obj.latitude.present? and obj.longitude.present? }
+
   after_validation :geocode, if: :will_save_change_to_address?
   include PgSearch::Model
   pg_search_scope :search_by_name_and_address,

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -8,8 +8,6 @@ class Restaurant < ApplicationRecord
               longitude: :fetched_longitude
   reverse_geocoded_by :latitude, :longitude
   after_validation :geocode, unless: ->(obj){ obj.address.present? and obj.latitude.present? and obj.longitude.present? }
-
-  after_validation :geocode, if: :will_save_change_to_address?
   include PgSearch::Model
   pg_search_scope :search_by_name_and_address,
                   against: [ :name, :address ],

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,9 +15,9 @@ Restaurant.destroy_all
 puts "seeding db with restaurants"
 apikey = "ytxKCmRhV2kPY8fEpKXN63SuuQSkVmPw"
 url = "https://tih-api.stb.gov.sg/content/v1/search/all?dataset=food_beverages&language=en&apikey=#{apikey}"
-count = 0
+# count = 0
 loop do
-  count += 1
+  # count += 1
   address_serialized = URI.open(url).read
   address_parsed = JSON.parse(address_serialized)
   next_token = address_parsed["nextToken"]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,15 +15,21 @@ Restaurant.destroy_all
 puts "seeding db with restaurants"
 apikey = "ytxKCmRhV2kPY8fEpKXN63SuuQSkVmPw"
 url = "https://tih-api.stb.gov.sg/content/v1/search/all?dataset=food_beverages&language=en&apikey=#{apikey}"
+count = 0
 loop do
+  count += 1
   address_serialized = URI.open(url).read
   address_parsed = JSON.parse(address_serialized)
-  nextToken = address_parsed["nextToken"]
-  puts "next token is: #{nextToken}"
+  next_token = address_parsed["nextToken"]
+  puts "next token is: #{next_token}"
   length_of_results = address_parsed["data"]["results"].length
   length_of_results.times do |index|
-    address_street = address_parsed["data"]["results"][index]["address"]
-    full_address = "#{address_street["block"]} #{address_street["streetName"]}, Singapore"
+    address = address_parsed["data"]["results"][index]["address"]
+    full_address = "
+    #{address['block']}
+    #{address['streetName']}
+    #{address['floorNumber']}-#{address['unitNumber']}
+    #{address['buildingName']} #{address['postalCode']}, Singapore"
     time = address_parsed["data"]["results"][index]["businessHour"]
     if time.empty?
       opening_time = ["10:00", "10:30", "11:00"].sample
@@ -45,8 +51,9 @@ loop do
     )
     puts "seeded #{address_parsed["data"]["results"][index]["name"]}"
   end
-  break if nextToken == ""
-  url = "https://tih-api.stb.gov.sg/content/v1/search/all?dataset=food_beverages&nextToken=#{nextToken}&language=en&apikey=#{apikey}"
+  break if next_token==""
+  # break if count==5
+  url = "https://tih-api.stb.gov.sg/content/v1/search/all?dataset=food_beverages&nextToken=#{next_token}&language=en&apikey=#{apikey}"
 end
 puts "seeding restaurant completed"
 


### PR DESCRIPTION
## Why

This pull request is needed because:

`Seed more restaurants using STB API, to have a more realistic experience`

[Link to Card]()

## What

This pull request introduces the following:

 * `rails db:seed will now seed all restaurants available on the STB api. It takes about 20 seconds`

Updated validations for restaurant model. It address & lat/long coordinates are already available, it will not perform any geocode api request. This increases the seeding performance by > 20x. Geocoder will only call the api and perform geocode when address is unavailable but latitude and longitude is available. When only address is available, Geocoder will do a reverse_geocode to get the latitude and longitude.

## How to Test

`Give the reviewer(s) some clues on how to test your PR`
`rails db:reset`
`rails c`
`Restaurant.count`

# Others
Potentially might create a composite index based on latitude and longitude for opitmisation purposes when invoking .near to search nearby restaurants
Create a new migrations file
`add_index :table, [:latitude, :longitude]`
