### PR TITLE
shows name when name exists

### DIFF
--- a/app/views/orders/success.html.erb
+++ b/app/views/orders/success.html.erb
@@ -1,5 +1,12 @@
 <div class="d-flex flex-column justify-content-center align-items-center text-center" style="height: 400px;">
-  <h2 class="order-success-text mt-5">Thank you, <%= current_user.email %>!</h2>
-  <h3 class="order-success-subtitle mb-5">Your order is on the way!</h3>
+  <h2 class="order-success-text mt-5">
+    Thank you,
+    <% if current_user.first_name.nil? %>
+      <%= current_user.email %>!
+    <% else %>
+      <%= current_user.first_name %>!
+    <% end %>
+  </h2>
+  <h3 class="order-success-subtitle mb-5">Your order is on the way</h3>
   <%= link_to "See more restaurants", restaurants_path, class: 'btn btn-primary' %>
 </div>

--- a/app/views/orders/success.html.erb
+++ b/app/views/orders/success.html.erb
@@ -1,7 +1,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center text-center" style="height: 400px;">
   <h2 class="order-success-text mt-5">
     Thank you,
-    <% if current_user.first_name.nil? %>
+    <% if current_user.first_name.nil? || current_user.first_name == "" %>
       <%= current_user.email %>!
     <% else %>
       <%= current_user.first_name %>!


### PR DESCRIPTION
## Why

Currently only shows email of user in thank you message in the /success page.

## What

If the user has a first name, it shows it instead.
If the user deletes the first name, it shows the email again instead of showing a blank name.

### Screenshot

<img width="356" alt="Screenshot 2021-09-19 at 2 16 50 PM" src="https://user-images.githubusercontent.com/11084577/133917542-510676cb-cf26-4e1e-a183-7a9c7a611125.png">

## How to Test

Go to the /success page without a first name, and with a first name, then without a first name again.