### PR TITLE
hotfix for correct greeting displaying at the time

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://www.jen-eats.com/tanglin/images/restaurants-and-bars/banner.jpg);">
   <div class="container d-flex flex-column justify-content-center mt-5">
     <div id="search-form">
-      <% if Time.now.hour >= 18 || Time.now.hour <= 23 %>
+      <% if Time.now.hour >= 18 && Time.now.hour <= 23 %>
         <h3>Good Evening</h3>
       <% elsif Time.now.hour >= 12%>
         <h3>Good Afternoon</h3>


### PR DESCRIPTION
## Why

This pull request is needed because:

* Greetings on the home page is not displaying the correct greeting based on time


## What

This pull request introduces the following:

 * Search form will display correct greeting now based on local time of day

### Screenshot

![image](https://user-images.githubusercontent.com/72695565/133956205-5738d2fb-1249-432a-bd95-5f10673d53a1.png)


## Other

It might show the europe local time instead as production servers are at europe, depending on where heroku is on.

